### PR TITLE
Check for delay slots in capability version of ERET

### DIFF
--- a/src/l3/cheri/exception.spec
+++ b/src/l3/cheri/exception.spec
@@ -165,6 +165,8 @@ unit SignalCapException_noReg (capException::CapExceptionType) =
 -- ERET instruction
 -----------------------------------
 define ERET =
+{
+   CheckBranch;
    if CP0.Status.CU0 or KernelMode then
    {
       if CP0.Status.ERL then
@@ -183,3 +185,4 @@ define ERET =
    }
    else
       SignalException (CpU)
+}


### PR DESCRIPTION
It's the same as the one in `mips-exception.spec`.